### PR TITLE
Simplify basic testing

### DIFF
--- a/.env.test.sample
+++ b/.env.test.sample
@@ -1,3 +1,3 @@
-FRECKLE_TOKEN={{Insert here the freckle's token API}}
-REAL_FRECKLE_USER_ID={{Insert here a real user id. This variable will use during the test.}}
-FRECKLE_URL={{Insert here an alternative freckle API url}}
+FRECKLE_TOKEN=token
+REAL_FRECKLE_USER_ID=12345
+FRECKLE_URL=https://example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env.*
+!.env.*.sample
 *.gem
 Gemfile.lock
 /coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ env:
   global:
     - CC_TEST_REPORTER_ID=d2619c7f36e46d99be646a88bdb206f69c90064f2473bc42665c2e489f9bf987
 language: ruby
+cache: bundler
 rvm:
   - 2.4
   - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
+  - cp .env.test.sample .env.test
 scripts:
   - bundle exec rspec spec
 after_script:

--- a/README.md
+++ b/README.md
@@ -40,15 +40,21 @@ You can set:
 
 # Testing
 
+The test suite uses the [VCR](https://github.com/vcr/vcr) gem.
+
+The contents of the cassettes is anonymized (see spec/spec_helper.rb).
+
+## Regenerating the VCR cassettes
+
+Occasionally, it is a good idea to regenerate the cassettes in order to
+do an end-to-end test.
+
 Make sure you have correctly set the `.env.test` file. Inside this file
 you must specify the keys:
 
 * `FRECKLE_TOKEN`: your Freckle API token;
 * `FRECKLE_URL`: Freckle API url;
 * `REAL_FRECKLE_USER_ID`: a real user id.
-
-The test suite uses the [VCR](https://github.com/vcr/vcr) gem.
-To regenerate the VCR cassettes, do as follows:
 
 ```shell
 $ rm -rf spec/fixtures/vcr_cassettes/*


### PR DESCRIPTION
* Only require special setup of .env.test when we need to
  regenerate VCR cassettes.